### PR TITLE
Add wallet transaction button to settings

### DIFF
--- a/ecp-client/SettingsView.swift
+++ b/ecp-client/SettingsView.swift
@@ -341,7 +341,7 @@ struct SettingsView: View {
                                     Image(systemName: "arrow.up.circle")
                                         .foregroundColor(.green)
                                 }
-                                Text(isFundingAppAccount ? "Sending..." : "Send 0.00003 ETH to App Account")
+                                Text(isFundingAppAccount ? "Sending..." : "Fund from wallet")
                                     .foregroundColor(.green)
                                 Spacer()
                                 if !isFundingAppAccount {


### PR DESCRIPTION
Add 'Fund App Account' section to the settings screen for users to send 0.00003 ETH to their app account.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd1462b-1264-456e-b420-4e1b57db4ff2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bd1462b-1264-456e-b420-4e1b57db4ff2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>